### PR TITLE
Update section snippet to new syntax

### DIFF
--- a/snippets/blade-section.sublime-snippet
+++ b/snippets/blade-section.sublime-snippet
@@ -2,7 +2,7 @@
 	<content><![CDATA[
 @section('${1:name}')
 	${2:{{--expr}
-@endsection$0
+@stop$0
 ]]></content>
 	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
 	<tabTrigger>sec</tabTrigger>


### PR DESCRIPTION
The syntax for sections has changed since Laravel 4. @endsection is now replaced by @stop.
