### PR TITLE
Create blade-layout-section.sublime-snippet

### DIFF
--- a/snippets/blade-layout-section.sublime-snippet
+++ b/snippets/blade-layout-section.sublime-snippet
@@ -1,0 +1,9 @@
+<snippet>
+	<content><![CDATA[
+@section('${1:name}')
+	${2:{{--expr}
+@show$0
+]]></content>
+	<tabTrigger>lsec</tabTrigger>
+	<scope>text.html.laravel-blade, text.html</scope>
+</snippet>


### PR DESCRIPTION
Since Laravel 4, sections inside layout files have their own syntax, requiring @show at the end. I propose to use the "lsec" (for "layout section") shortcut for this new snippet.
