### PR TITLE
Update yield snippet to add optional default content

### DIFF
--- a/snippets/blade-yield.sublime-snippet
+++ b/snippets/blade-yield.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[
-@yield('${1:name}')$0
+@yield('${1:name}'${2:, '${3:default}'})$0
 ]]></content>
 	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
 	<tabTrigger>yl</tabTrigger>


### PR DESCRIPTION
Blade syntax now allows to pass an optional second parameter to @yield, specifying a default value in case where the section has not been defined in the parent view.
