### PR TITLE
stopped section snippet from tabbing out of contents area

### DIFF
--- a/snippets/blade-section.sublime-snippet
+++ b/snippets/blade-section.sublime-snippet
@@ -2,7 +2,7 @@
 	<content><![CDATA[
 @section('${1:name}')
 	${2:{{-- expr --\}\}}
-@stop$0
+@stop
 ]]></content>
 	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
 	<tabTrigger>sec</tabTrigger>


### PR DESCRIPTION
Was always having an issue that I had to tab to the end of the section before i could add content as i couldn't auto finish until i had