### PR TITLE
Add can and can else snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Or download the snippets zip file and unzip it into your Packages folder.
 
 | Shortcut  | Result |
 |-----------|--------|
+| can       | @can('`policy`', $model) <br /> **{{-- expr --\}\}** <br /> @endcan |
+| cane      | @can('`policy`', $model) <br /> **{{-- expr --\}\}** <br /> @else <br /> **{{-- expr --\}\}** @endcan |
 | ext		| @extends('`name`') |
 | lay		| @layout('`name`')  |
 | sec		| @section('`name`') <br /> **{{-- expr --\}\}** <br /> @endsection    |
@@ -46,7 +48,7 @@ Or download the snippets zip file and unzip it into your Packages folder.
 | unless	| @unless (`condition`) <br /> **{{-- expr --\}\}** <br /> @endunless  |
 | choise	| @choice('`language.line`', $`number`)  |
 | comment	| {{-- `comment` --}}	|
-| lang		| @lang('`language.line`', array('`variable` => '`replacement`'))  | 
+| lang		| @lang('`language.line`', array('`variable` => '`replacement`'))  |
 
 
 ---

--- a/snippets/blade-can.sublime-snippet
+++ b/snippets/blade-can.sublime-snippet
@@ -1,0 +1,11 @@
+<snippet>
+    <content><![CDATA[
+@can('${1:policy}', \$${2:model})
+    ${3:{{-- expr --\}\}}
+@endcan
+]]></content>
+    <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
+    <tabTrigger>can</tabTrigger>
+    <!-- Optional: Set a scope to limit where the snippet will trigger -->
+    <scope>text.html.laravel-blade</scope>
+</snippet>

--- a/snippets/blade-can_else.sublime-snippet
+++ b/snippets/blade-can_else.sublime-snippet
@@ -1,0 +1,13 @@
+<snippet>
+    <content><![CDATA[
+@can('${1:policy}', \$${2:model})
+    ${3:{{-- expr --\}\}}
+@else
+    ${3:{{-- else expr --\}\}}
+@endcan$0
+]]></content>
+    <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
+    <tabTrigger>cane</tabTrigger>
+    <!-- Optional: Set a scope to limit where the snippet will trigger -->
+    <scope>text.html.laravel-blade</scope>
+</snippet>


### PR DESCRIPTION
Add `can` and `cane` snippets for the shiny new [authorization Blade directives](http://laravel.com/docs/5.1/authorization#within-blade-templates) in Laravel 5.1.11.