### PR TITLE
Add Envoy snippets and fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Or clone this repository into your Packages folder:
 
 Or download the snippets zip file and unzip it into your Packages folder.
 
-##Avalable snippets
+##Available snippets
 
 | Shortcut  | Result |
 |-----------|--------|

--- a/README.md
+++ b/README.md
@@ -56,6 +56,21 @@ Or download the snippets zip file and unzip it into your Packages folder.
 | inject    | @inject('`name`', '`App\Services\ServiceName`') |
 
 
+##Envoy snippets
+
+Snippets for [Laravel Envoy](https://laravel.com/docs/5.2/envoy).
+
+| Shortcut  | Result |
+|-----------|--------|
+| serv      | @servers(['`web`' => '`user@192.168.1.1`']) |
+| task      | @task('`foo`') <br /> **command** <br /> @endtask    |
+| set       | @setup <br /> **{{-- expr --\}\}** <br /> @endsetup    |
+| mac       | @macro('`deploy') <br /> **command** <br /> @endmacro    |
+| aft       | @after<br /> **hip** <br /> @endafter    |
+| hip       | @hipchat('token', 'room', 'Envoy', "$task ran in the $env environment.") |
+| sla       | @slack('hook', 'channel', 'message') |
+
+
 ---
 Original snippets by:
 [@dev4dev](https://github.com/dev4dev)

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Or download the snippets zip file and unzip it into your Packages folder.
 | unless	| @unless (`condition`) <br /> **{{-- expr --\}\}** <br /> @endunless  |
 | choise	| @choice('`language.line`', $`number`)  |
 | comment	| {{-- `comment` --}}	|
-| lang		| @lang('`language.line`', array('`variable` => '`replacement`'))  |
+| lang		| @lang('`language.line`', ['`variable` => '`replacement`'])  |
 | inject    | @inject('`name`', '`App\Services\ServiceName`') |
 
 

--- a/snippets/blade-after.sublime-snippet
+++ b/snippets/blade-after.sublime-snippet
@@ -1,0 +1,11 @@
+<snippet>
+	<content><![CDATA[
+@after
+	${0:hip}
+@endafter
+]]></content>
+	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
+	<tabTrigger>after</tabTrigger>
+	<!-- Optional: Set a scope to limit where the snippet will trigger -->
+	<scope>text.blade</scope>
+</snippet>

--- a/snippets/blade-hipchat.sublime-snippet
+++ b/snippets/blade-hipchat.sublime-snippet
@@ -1,0 +1,9 @@
+<snippet>
+	<content><![CDATA[
+@hipchat(['${1:token}', '${2:room}', "${3:$task ran in the $env environment.}")$0
+]]></content>
+	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
+	<tabTrigger>hip</tabTrigger>
+	<!-- Optional: Set a scope to limit where the snippet will trigger -->
+	<scope>text.blade</scope>
+</snippet>

--- a/snippets/blade-macro.sublime-snippet
+++ b/snippets/blade-macro.sublime-snippet
@@ -1,0 +1,11 @@
+<snippet>
+	<content><![CDATA[
+@macro('${1:deploy}')
+	${0:command}
+@endmacro
+]]></content>
+	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
+	<tabTrigger>macro</tabTrigger>
+	<!-- Optional: Set a scope to limit where the snippet will trigger -->
+	<scope>text.blade</scope>
+</snippet>

--- a/snippets/blade-servers.sublime-snippet
+++ b/snippets/blade-servers.sublime-snippet
@@ -1,0 +1,9 @@
+<snippet>
+	<content><![CDATA[
+@servers(['${1:web}' => '${2:user@192.168.1.1}'])$0
+]]></content>
+	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
+	<tabTrigger>serv</tabTrigger>
+	<!-- Optional: Set a scope to limit where the snippet will trigger -->
+	<scope>text.blade</scope>
+</snippet>

--- a/snippets/blade-setup.sublime-snippet
+++ b/snippets/blade-setup.sublime-snippet
@@ -1,0 +1,11 @@
+<snippet>
+	<content><![CDATA[
+@setup
+	${0:{{-- expr --\}\}}
+@endsetup
+]]></content>
+	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
+	<tabTrigger>setup</tabTrigger>
+	<!-- Optional: Set a scope to limit where the snippet will trigger -->
+	<scope>text.blade</scope>
+</snippet>

--- a/snippets/blade-slack.sublime-snippet
+++ b/snippets/blade-slack.sublime-snippet
@@ -1,0 +1,9 @@
+<snippet>
+	<content><![CDATA[
+@slack('${1:hook}', '${2:channel}', '${3:message}')$0
+]]></content>
+	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
+	<tabTrigger>sla</tabTrigger>
+	<!-- Optional: Set a scope to limit where the snippet will trigger -->
+	<scope>text.blade</scope>
+</snippet>

--- a/snippets/blade-task.sublime-snippet
+++ b/snippets/blade-task.sublime-snippet
@@ -1,0 +1,11 @@
+<snippet>
+	<content><![CDATA[
+@task('${1:foo}', ['${2:on}' => '${3:web}'])
+	${0:command}
+@endtask
+]]></content>
+	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
+	<tabTrigger>task</tabTrigger>
+	<!-- Optional: Set a scope to limit where the snippet will trigger -->
+	<scope>text.blade</scope>
+</snippet>


### PR DESCRIPTION
Snippets for [Laravel Envoy](https://laravel.com/docs/5.2/envoy) which happens to use the Blade syntax too.