### PR TITLE
Add snippet for the new alternative to the Laravel trans helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ See the Laravel [Policies documentation](https://laravel.com/docs/5.3/authorizat
 | inject    | @inject('`name`', '`App\Services\ServiceName`') |
 | trans     | {{ trans('`language.line`') }}    |
 | lang      | @lang('`language.line`', ['`variable` => '`replacement`'])  |
+| __        | {{ __('`language.line`') }}    |
 
 ---
 

--- a/snippets/blade-trans_variant.sublime-snippet
+++ b/snippets/blade-trans_variant.sublime-snippet
@@ -1,0 +1,7 @@
+<snippet>
+    <content><![CDATA[
+{{ __('${0:language.line}') }}
+]]></content>
+    <tabTrigger>__</tabTrigger>
+    <scope>text.blade</scope>
+</snippet>


### PR DESCRIPTION
Laravel 5.4 includes a new alternative to the `trans('language.key')` helper, `__('language.key')`.

[https://laravel.com/docs/5.4/localization#retrieving-translation-strings](https://laravel.com/docs/5.4/localization#retrieving-translation-strings)