### PR TITLE
Adjust selectors for Sublime Text 4 and refactored Blade syntax

### DIFF
--- a/snippets/blade-acfrepeater.sublime-snippet
+++ b/snippets/blade-acfrepeater.sublime-snippet
@@ -1,12 +1,10 @@
 <snippet>
-    <content><![CDATA[
+	<content><![CDATA[
 @acfrepeater (${1:'fieldname'})
-    ${2:{{-- expr --\}\}}
-    {{ get_sub_field(${1:'fieldname'}) \}\}
+	${2:{{-- expr --\}\}}
+	{{ get_sub_field(${1:'fieldname'}) \}\}
 @acfend$0
 ]]></content>
-    <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
-    <tabTrigger>acf</tabTrigger>
-    <!-- Optional: Set a scope to limit where the snippet will trigger -->
-    <scope>text.blade</scope>
+	<tabTrigger>acf</tabTrigger>
+	<scope>(text.blade | text.html.blade | source.css.blade | source.js.blade) - custom.compiler.blade - meta.embedded.blade - source.php - text.plain - punctuation.section.embedded</scope>
 </snippet>

--- a/snippets/blade-after.sublime-snippet
+++ b/snippets/blade-after.sublime-snippet
@@ -4,8 +4,6 @@
 	${0:hip}
 @endafter
 ]]></content>
-	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
 	<tabTrigger>after</tabTrigger>
-	<!-- Optional: Set a scope to limit where the snippet will trigger -->
-	<scope>text.blade</scope>
+	<scope>(text.blade | text.html.blade | source.css.blade | source.js.blade) - custom.compiler.blade - meta.embedded.blade - source.php - text.plain - punctuation.section.embedded</scope>
 </snippet>

--- a/snippets/blade-asset.sublime-snippet
+++ b/snippets/blade-asset.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
-    <content><![CDATA[
+	<content><![CDATA[
 {{ asset('${0:path}') }}
 ]]></content>
-    <tabTrigger>asset</tabTrigger>
-    <scope>text.blade</scope>
+	<tabTrigger>asset</tabTrigger>
+	<scope>(text.blade | text.html.blade | source.css.blade | source.js.blade) - custom.compiler.blade - meta.embedded.blade - source.php - text.plain - punctuation.section.embedded</scope>
 </snippet>

--- a/snippets/blade-auth.sublime-snippet
+++ b/snippets/blade-auth.sublime-snippet
@@ -4,8 +4,6 @@
 	${3:{{-- expr --\}\}}
 @endauth$0
 ]]></content>
-	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
 	<tabTrigger>auth</tabTrigger>
-	<!-- Optional: Set a scope to limit where the snippet will trigger -->
-	<scope>text.blade</scope>
+	<scope>(text.blade | text.html.blade | source.css.blade | source.js.blade) - custom.compiler.blade - meta.embedded.blade - source.php - text.plain - punctuation.section.embedded</scope>
 </snippet>

--- a/snippets/blade-break.sublime-snippet
+++ b/snippets/blade-break.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
-    <content><![CDATA[
+	<content><![CDATA[
 @break${1:('${2:condition}')}
 ]]></content>
-    <tabTrigger>break</tabTrigger>
-    <scope>text.blade</scope>
+	<tabTrigger>break</tabTrigger>
+	<scope>(text.blade | text.html.blade | source.css.blade | source.js.blade) - custom.compiler.blade - meta.embedded.blade - source.php - text.plain - punctuation.section.embedded</scope>
 </snippet>

--- a/snippets/blade-can.sublime-snippet
+++ b/snippets/blade-can.sublime-snippet
@@ -1,11 +1,9 @@
 <snippet>
-    <content><![CDATA[
+	<content><![CDATA[
 @can('${1:policy}', ${2:Model}::class)
-    ${3:{{-- expr --\}\}}
+	${3:{{-- expr --\}\}}
 @endcan
 ]]></content>
-    <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
-    <tabTrigger>can</tabTrigger>
-    <!-- Optional: Set a scope to limit where the snippet will trigger -->
-    <scope>text.blade</scope>
+	<tabTrigger>can</tabTrigger>
+	<scope>(text.blade | text.html.blade | source.css.blade | source.js.blade) - custom.compiler.blade - meta.embedded.blade - source.php - text.plain - punctuation.section.embedded</scope>
 </snippet>

--- a/snippets/blade-can_else.sublime-snippet
+++ b/snippets/blade-can_else.sublime-snippet
@@ -1,13 +1,11 @@
 <snippet>
-    <content><![CDATA[
+	<content><![CDATA[
 @can('${1:policy}', \$${2:model})
-    ${3:{{-- expr --\}\}}
+	${3:{{-- expr --\}\}}
 @else
-    ${4:{{-- else expr --\}\}}
+	${4:{{-- else expr --\}\}}
 @endcan$0
 ]]></content>
-    <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
-    <tabTrigger>cane</tabTrigger>
-    <!-- Optional: Set a scope to limit where the snippet will trigger -->
-    <scope>text.blade</scope>
+	<tabTrigger>cane</tabTrigger>
+	<scope>(text.blade | text.html.blade | source.css.blade | source.js.blade) - custom.compiler.blade - meta.embedded.blade - source.php - text.plain - punctuation.section.embedded</scope>
 </snippet>

--- a/snippets/blade-canany.sublime-snippet
+++ b/snippets/blade-canany.sublime-snippet
@@ -1,11 +1,9 @@
 <snippet>
-    <content><![CDATA[
+	<content><![CDATA[
 @canany(['${1:policy}', '${2:policy}'], ${3:${4:Model}::class})
-    ${5:{{-- expr --\}\}}
+	${5:{{-- expr --\}\}}
 @endcanany
 ]]></content>
-    <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
-    <tabTrigger>canany</tabTrigger>
-    <!-- Optional: Set a scope to limit where the snippet will trigger -->
-    <scope>text.blade</scope>
+	<tabTrigger>canany</tabTrigger>
+	<scope>(text.blade | text.html.blade | source.css.blade | source.js.blade) - custom.compiler.blade - meta.embedded.blade - source.php - text.plain - punctuation.section.embedded</scope>
 </snippet>

--- a/snippets/blade-canany_else.sublime-snippet
+++ b/snippets/blade-canany_else.sublime-snippet
@@ -1,13 +1,11 @@
 <snippet>
-    <content><![CDATA[
+	<content><![CDATA[
 @canany(['${1:policy}', '${2:policy}'], ${3:${4:Model}::class})
-    ${5:{{-- expr --\}\}}
+	${5:{{-- expr --\}\}}
 @elsecanany(['${6:policy}', '${7:policy}'], ${8:${9:Model}::class})
-    ${10:{{-- else expr --\}\}}
+	${10:{{-- else expr --\}\}}
 @endcanany
 ]]></content>
-    <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
-    <tabTrigger>cananye</tabTrigger>
-    <!-- Optional: Set a scope to limit where the snippet will trigger -->
-    <scope>text.blade</scope>
+	<tabTrigger>cananye</tabTrigger>
+	<scope>(text.blade | text.html.blade | source.css.blade | source.js.blade) - custom.compiler.blade - meta.embedded.blade - source.php - text.plain - punctuation.section.embedded</scope>
 </snippet>

--- a/snippets/blade-cannot.sublime-snippet
+++ b/snippets/blade-cannot.sublime-snippet
@@ -1,10 +1,10 @@
 <snippet>
-    <content><![CDATA[
+	<content><![CDATA[
 @cannot('${1:policy}', ${2:Model}::class)
-    ${3:{{-- expr --\}\}}
+	${3:{{-- expr --\}\}}
 @endcannot
 ]]></content>
-    <tabTrigger>cannot</tabTrigger>
-    <scope>text.blade</scope>
-    <description>See if user can't perform an action</description>
+	<tabTrigger>cannot</tabTrigger>
+	<scope>(text.blade | text.html.blade | source.css.blade | source.js.blade) - custom.compiler.blade - meta.embedded.blade - source.php - text.plain - punctuation.section.embedded</scope>
+	<description>See if user can't perform an action</description>
 </snippet>

--- a/snippets/blade-cannot_else.sublime-snippet
+++ b/snippets/blade-cannot_else.sublime-snippet
@@ -1,12 +1,12 @@
 <snippet>
-    <content><![CDATA[
+	<content><![CDATA[
 @cannot('${1:policy}', \$${2:model})
-    ${3:{{-- expr --\}\}}
+	${3:{{-- expr --\}\}}
 @else
-    ${4:{{-- else expr --\}\}}
+	${4:{{-- else expr --\}\}}
 @endcannot
 ]]></content>
-    <tabTrigger>cannote</tabTrigger>
-    <scope>text.blade</scope>
-    <description>See if user can't perform an action with else</description>
+	<tabTrigger>cannote</tabTrigger>
+	<scope>(text.blade | text.html.blade | source.css.blade | source.js.blade) - custom.compiler.blade - meta.embedded.blade - source.php - text.plain - punctuation.section.embedded</scope>
+	<description>See if user can't perform an action with else</description>
 </snippet>

--- a/snippets/blade-choice.sublime-snippet
+++ b/snippets/blade-choice.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
-    <content><![CDATA[
+	<content><![CDATA[
 @choice('${1:language.line}', ${2:number})
 ]]></content>
-    <tabTrigger>choice</tabTrigger>
-    <scope>text.blade</scope>
+	<tabTrigger>choice</tabTrigger>
+	<scope>(text.blade | text.html.blade | source.css.blade | source.js.blade) - custom.compiler.blade - meta.embedded.blade - source.php - text.plain - punctuation.section.embedded</scope>
 </snippet>

--- a/snippets/blade-comment.sublime-snippet
+++ b/snippets/blade-comment.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
-    <content><![CDATA[
+	<content><![CDATA[
 {{-- ${0:comment} --}}
 ]]></content>
-    <tabTrigger>comment</tabTrigger>
-    <scope>text.blade</scope>
+	<tabTrigger>comment</tabTrigger>
+	<scope>(text.blade | text.html.blade | source.css.blade | source.js.blade) - custom.compiler.blade - meta.embedded.blade - source.php - text.plain - punctuation.section.embedded</scope>
 </snippet>

--- a/snippets/blade-component.sublime-snippet
+++ b/snippets/blade-component.sublime-snippet
@@ -1,10 +1,10 @@
 <snippet>
-    <content><![CDATA[
+	<content><![CDATA[
 @component('${1:component}', '${2:array}')
-    $3
+	$3
 @endcomponent
 ]]></content>
-    <tabTrigger>comp</tabTrigger>
-    <scope>text.blade</scope>
-    <description>Defines a component and passes array with data</description>
+	<tabTrigger>comp</tabTrigger>
+	<scope>(text.blade | text.html.blade | source.css.blade | source.js.blade) - custom.compiler.blade - meta.embedded.blade - source.php - text.plain - punctuation.section.embedded</scope>
+	<description>Defines a component and passes array with data</description>
 </snippet>

--- a/snippets/blade-continue.sublime-snippet
+++ b/snippets/blade-continue.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
-    <content><![CDATA[
+	<content><![CDATA[
 @continue${1:('${2:condition}')}
 ]]></content>
-    <tabTrigger>continue</tabTrigger>
-    <scope>text.blade</scope>
+	<tabTrigger>continue</tabTrigger>
+	<scope>(text.blade | text.html.blade | source.css.blade | source.js.blade) - custom.compiler.blade - meta.embedded.blade - source.php - text.plain - punctuation.section.embedded</scope>
 </snippet>

--- a/snippets/blade-csrf.sublime-snippet
+++ b/snippets/blade-csrf.sublime-snippet
@@ -1,10 +1,8 @@
 <snippet>
-    <content><![CDATA[
+	<content><![CDATA[
 @csrf
 $0
 ]]></content>
-    <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
-    <tabTrigger>csrf</tabTrigger>
-    <!-- Optional: Set a scope to limit where the snippet will trigger -->
-    <scope>text.blade</scope>
+	<tabTrigger>csrf</tabTrigger>
+	<scope>(text.blade | text.html.blade | source.css.blade | source.js.blade) - custom.compiler.blade - meta.embedded.blade - source.php - text.plain - punctuation.section.embedded</scope>
 </snippet>

--- a/snippets/blade-dump.sublime-snippet
+++ b/snippets/blade-dump.sublime-snippet
@@ -1,9 +1,7 @@
 <snippet>
-    <content><![CDATA[
+	<content><![CDATA[
 @dump(${0:expression})
 ]]></content>
-    <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
-    <tabTrigger>dump</tabTrigger>
-    <!-- Optional: Set a scope to limit where the snippet will trigger -->
-    <scope>text.blade</scope>
+	<tabTrigger>dump</tabTrigger>
+	<scope>(text.blade | text.html.blade | source.css.blade | source.js.blade) - custom.compiler.blade - meta.embedded.blade - source.php - text.plain - punctuation.section.embedded</scope>
 </snippet>

--- a/snippets/blade-each.sublime-snippet
+++ b/snippets/blade-each.sublime-snippet
@@ -2,8 +2,6 @@
 	<content><![CDATA[
 @each ('${1:item.view}', ${2:\$items}, '${3:item}', '${4:empty.view}')$0
 ]]></content>
-	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
 	<tabTrigger>each</tabTrigger>
-	<!-- Optional: Set a scope to limit where the snippet will trigger -->
-	<scope>text.blade</scope>
+	<scope>(text.blade | text.html.blade | source.css.blade | source.js.blade) - custom.compiler.blade - meta.embedded.blade - source.php - text.plain - punctuation.section.embedded</scope>
 </snippet>

--- a/snippets/blade-elseif.sublime-snippet
+++ b/snippets/blade-elseif.sublime-snippet
@@ -1,10 +1,8 @@
 <snippet>
-    <content><![CDATA[
+	<content><![CDATA[
 @elseif (${1:condition})
-    ${2:{{-- true expr --\}\}}$0
+	${2:{{-- true expr --\}\}}$0
 ]]></content>
-    <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
-    <tabTrigger>eif</tabTrigger>
-    <!-- Optional: Set a scope to limit where the snippet will trigger -->
-    <scope>text.blade</scope>
+	<tabTrigger>eif</tabTrigger>
+	<scope>(text.blade | text.html.blade | source.css.blade | source.js.blade) - custom.compiler.blade - meta.embedded.blade - source.php - text.plain - punctuation.section.embedded</scope>
 </snippet>

--- a/snippets/blade-empty.sublime-snippet
+++ b/snippets/blade-empty.sublime-snippet
@@ -1,10 +1,10 @@
 <snippet>
-    <content><![CDATA[
+	<content><![CDATA[
 @empty ($1)
-    $2
+	$2
 @endempty
 ]]></content>
-    <tabTrigger>empty</tabTrigger>
-    <scope>text.blade</scope>
-    <description>Defines an empty statement</description>
+	<tabTrigger>empty</tabTrigger>
+	<scope>(text.blade | text.html.blade | source.css.blade | source.js.blade) - custom.compiler.blade - meta.embedded.blade - source.php - text.plain - punctuation.section.embedded</scope>
+	<description>Defines an empty statement</description>
 </snippet>

--- a/snippets/blade-expr.sublime-snippet
+++ b/snippets/blade-expr.sublime-snippet
@@ -2,8 +2,6 @@
 	<content><![CDATA[
 {{ ${0:expression} }}
 ]]></content>
-	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
 	<tabTrigger>}}</tabTrigger>
-	<!-- Optional: Set a scope to limit where the snippet will trigger -->
-	<scope>text.blade</scope>
+	<scope>(text.blade | text.html.blade | source.css.blade | source.js.blade) - custom.compiler.blade - meta.embedded.blade - source.php - text.plain - punctuation.section.embedded</scope>
 </snippet>

--- a/snippets/blade-expr_js.sublime-snippet
+++ b/snippets/blade-expr_js.sublime-snippet
@@ -2,8 +2,6 @@
 	<content><![CDATA[
 @{{ ${1:expression} }}
 ]]></content>
-	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
 	<tabTrigger>@{{</tabTrigger>
-	<!-- Optional: Set a scope to limit where the snippet will trigger -->
-	<scope>text.blade</scope>
+	<scope>(text.blade | text.html.blade | source.css.blade | source.js.blade) - custom.compiler.blade - meta.embedded.blade - source.php - text.plain - punctuation.section.embedded</scope>
 </snippet>

--- a/snippets/blade-extends.sublime-snippet
+++ b/snippets/blade-extends.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
-    <content><![CDATA[
+	<content><![CDATA[
 @extends('${1:view}')$0
 ]]></content>
-    <tabTrigger>ext</tabTrigger>
-    <scope>text.blade</scope>
+	<tabTrigger>ext</tabTrigger>
+	<scope>(text.blade | text.html.blade | source.css.blade | source.js.blade) - custom.compiler.blade - meta.embedded.blade - source.php - text.plain - punctuation.section.embedded</scope>
 </snippet>

--- a/snippets/blade-for.sublime-snippet
+++ b/snippets/blade-for.sublime-snippet
@@ -4,8 +4,6 @@
 	${6:{{-- expr --\}\}}
 @endfor$0
 ]]></content>
-	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
 	<tabTrigger>for</tabTrigger>
-	<!-- Optional: Set a scope to limit where the snippet will trigger -->
-	<scope>text.blade</scope>
+	<scope>(text.blade | text.html.blade | source.css.blade | source.js.blade) - custom.compiler.blade - meta.embedded.blade - source.php - text.plain - punctuation.section.embedded</scope>
 </snippet>

--- a/snippets/blade-fore.sublime-snippet
+++ b/snippets/blade-fore.sublime-snippet
@@ -6,8 +6,6 @@
 	${4:{{-- empty expr --\}\}}
 @endforelse$0
 ]]></content>
-	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
 	<tabTrigger>fore</tabTrigger>
-	<!-- Optional: Set a scope to limit where the snippet will trigger -->
-	<scope>text.blade</scope>
+	<scope>(text.blade | text.html.blade | source.css.blade | source.js.blade) - custom.compiler.blade - meta.embedded.blade - source.php - text.plain - punctuation.section.embedded</scope>
 </snippet>

--- a/snippets/blade-foreach.sublime-snippet
+++ b/snippets/blade-foreach.sublime-snippet
@@ -4,8 +4,6 @@
 	${3:{{-- expr --\}\}}
 @endforeach$0
 ]]></content>
-	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
 	<tabTrigger>foreach</tabTrigger>
-	<!-- Optional: Set a scope to limit where the snippet will trigger -->
-	<scope>text.blade</scope>
+	<scope>(text.blade | text.html.blade | source.css.blade | source.js.blade) - custom.compiler.blade - meta.embedded.blade - source.php - text.plain - punctuation.section.embedded</scope>
 </snippet>

--- a/snippets/blade-guest.sublime-snippet
+++ b/snippets/blade-guest.sublime-snippet
@@ -4,8 +4,6 @@
 	${3:{{-- expr --\}\}}
 @endguest$0
 ]]></content>
-	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
 	<tabTrigger>guest</tabTrigger>
-	<!-- Optional: Set a scope to limit where the snippet will trigger -->
-	<scope>text.blade</scope>
+	<scope>(text.blade | text.html.blade | source.css.blade | source.js.blade) - custom.compiler.blade - meta.embedded.blade - source.php - text.plain - punctuation.section.embedded</scope>
 </snippet>

--- a/snippets/blade-has_section.sublime-snippet
+++ b/snippets/blade-has_section.sublime-snippet
@@ -6,8 +6,6 @@
 	${3:{{-- false expr --\}\}}
 @endif$0
 ]]></content>
-	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
 	<tabTrigger>hass</tabTrigger>
-	<!-- Optional: Set a scope to limit where the snippet will trigger -->
-	<scope>text.blade</scope>
+	<scope>(text.blade | text.html.blade | source.css.blade | source.js.blade) - custom.compiler.blade - meta.embedded.blade - source.php - text.plain - punctuation.section.embedded</scope>
 </snippet>

--- a/snippets/blade-hipchat.sublime-snippet
+++ b/snippets/blade-hipchat.sublime-snippet
@@ -2,8 +2,6 @@
 	<content><![CDATA[
 @hipchat(['${1:token}', '${2:room}', "${3:$task ran in the $env environment.}")$0
 ]]></content>
-	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
 	<tabTrigger>hip</tabTrigger>
-	<!-- Optional: Set a scope to limit where the snippet will trigger -->
-	<scope>text.blade</scope>
+	<scope>(text.blade | text.html.blade | source.css.blade | source.js.blade) - custom.compiler.blade - meta.embedded.blade - source.php - text.plain - punctuation.section.embedded</scope>
 </snippet>

--- a/snippets/blade-if.sublime-snippet
+++ b/snippets/blade-if.sublime-snippet
@@ -4,8 +4,6 @@
 	${2:{{-- expr --\}\}}
 @endif$0
 ]]></content>
-	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
 	<tabTrigger>if</tabTrigger>
-	<!-- Optional: Set a scope to limit where the snippet will trigger -->
-	<scope>text.blade</scope>
+	<scope>(text.blade | text.html.blade | source.css.blade | source.js.blade) - custom.compiler.blade - meta.embedded.blade - source.php - text.plain - punctuation.section.embedded</scope>
 </snippet>

--- a/snippets/blade-if_else.sublime-snippet
+++ b/snippets/blade-if_else.sublime-snippet
@@ -6,8 +6,6 @@
 	${3:{{-- false expr --\}\}}
 @endif$0
 ]]></content>
-	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
 	<tabTrigger>ife</tabTrigger>
-	<!-- Optional: Set a scope to limit where the snippet will trigger -->
-	<scope>text.blade</scope>
+	<scope>(text.blade | text.html.blade | source.css.blade | source.js.blade) - custom.compiler.blade - meta.embedded.blade - source.php - text.plain - punctuation.section.embedded</scope>
 </snippet>

--- a/snippets/blade-include.sublime-snippet
+++ b/snippets/blade-include.sublime-snippet
@@ -2,8 +2,6 @@
 	<content><![CDATA[
 @include('${1:view.name}'${2:, [${3:'some'} => ${4:'data'}]})$0
 ]]></content>
-	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
 	<tabTrigger>inc</tabTrigger>
-	<!-- Optional: Set a scope to limit where the snippet will trigger -->
-	<scope>text.blade</scope>
+	<scope>(text.blade | text.html.blade | source.css.blade | source.js.blade) - custom.compiler.blade - meta.embedded.blade - source.php - text.plain - punctuation.section.embedded</scope>
 </snippet>

--- a/snippets/blade-includeIf.sublime-snippet
+++ b/snippets/blade-includeIf.sublime-snippet
@@ -2,8 +2,6 @@
 	<content><![CDATA[
 @includeIf('${1:view.name}'${2:, [${3:'some'} => ${4:'data'}]})$0
 ]]></content>
-	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
 	<tabTrigger>incif</tabTrigger>
-	<!-- Optional: Set a scope to limit where the snippet will trigger -->
-	<scope>text.blade</scope>
+	<scope>(text.blade | text.html.blade | source.css.blade | source.js.blade) - custom.compiler.blade - meta.embedded.blade - source.php - text.plain - punctuation.section.embedded</scope>
 </snippet>

--- a/snippets/blade-includefirst.sublime-snippet
+++ b/snippets/blade-includefirst.sublime-snippet
@@ -1,9 +1,7 @@
 <snippet>
-    <content><![CDATA[
+	<content><![CDATA[
 @includeFirst(['${1:custom.admin}', '${2:admin}']${3:, [${4:'some'} => ${5:'data'}]})$0
 ]]></content>
-    <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
-    <tabTrigger>incf</tabTrigger>
-    <!-- Optional: Set a scope to limit where the snippet will trigger -->
-    <scope>text.blade</scope>
+	<tabTrigger>incf</tabTrigger>
+	<scope>(text.blade | text.html.blade | source.css.blade | source.js.blade) - custom.compiler.blade - meta.embedded.blade - source.php - text.plain - punctuation.section.embedded</scope>
 </snippet>

--- a/snippets/blade-includewhen.sublime-snippet
+++ b/snippets/blade-includewhen.sublime-snippet
@@ -1,9 +1,7 @@
 <snippet>
-    <content><![CDATA[
+	<content><![CDATA[
 @includeWhen(${1:boolean}, '${2:view.name}'${3:, [${4:'some'} => ${5:'data'}]})$0
 ]]></content>
-    <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
-    <tabTrigger>incwhen</tabTrigger>
-    <!-- Optional: Set a scope to limit where the snippet will trigger -->
-    <scope>text.blade</scope>
+	<tabTrigger>incwhen</tabTrigger>
+	<scope>(text.blade | text.html.blade | source.css.blade | source.js.blade) - custom.compiler.blade - meta.embedded.blade - source.php - text.plain - punctuation.section.embedded</scope>
 </snippet>

--- a/snippets/blade-inject.sublime-snippet
+++ b/snippets/blade-inject.sublime-snippet
@@ -2,8 +2,6 @@
 	<content><![CDATA[
 @inject('${1:name}', ${2:'App\Services\ServiceName'})$0
 ]]></content>
-	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
 	<tabTrigger>inject</tabTrigger>
-	<!-- Optional: Set a scope to limit where the snippet will trigger -->
-	<scope>text.blade</scope>
+	<scope>(text.blade | text.html.blade | source.css.blade | source.js.blade) - custom.compiler.blade - meta.embedded.blade - source.php - text.plain - punctuation.section.embedded</scope>
 </snippet>

--- a/snippets/blade-isset.sublime-snippet
+++ b/snippets/blade-isset.sublime-snippet
@@ -1,10 +1,10 @@
 <snippet>
-    <content><![CDATA[
+	<content><![CDATA[
 @isset ($1)
-    $2
+	$2
 @endisset
 ]]></content>
-    <tabTrigger>isset</tabTrigger>
-    <scope>text.blade</scope>
-    <description>Defines an isset statement</description>
+	<tabTrigger>isset</tabTrigger>
+	<scope>(text.blade | text.html.blade | source.css.blade | source.js.blade) - custom.compiler.blade - meta.embedded.blade - source.php - text.plain - punctuation.section.embedded</scope>
+	<description>Defines an isset statement</description>
 </snippet>

--- a/snippets/blade-json.sublime-snippet
+++ b/snippets/blade-json.sublime-snippet
@@ -1,9 +1,7 @@
 <snippet>
-    <content><![CDATA[
+	<content><![CDATA[
 @json(${0:expression})
 ]]></content>
-    <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
-    <tabTrigger>json</tabTrigger>
-    <!-- Optional: Set a scope to limit where the snippet will trigger -->
-    <scope>text.blade</scope>
+	<tabTrigger>json</tabTrigger>
+	<scope>(text.blade | text.html.blade | source.css.blade | source.js.blade) - custom.compiler.blade - meta.embedded.blade - source.php - text.plain - punctuation.section.embedded</scope>
 </snippet>

--- a/snippets/blade-lang.sublime-snippet
+++ b/snippets/blade-lang.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
-    <content><![CDATA[
+	<content><![CDATA[
 @lang('${1:language.line}'${2:, [${3:'variable'} => ${4:'replacement'}]})
 ]]></content>
-    <tabTrigger>lang</tabTrigger>
-    <scope>text.blade</scope>
+	<tabTrigger>lang</tabTrigger>
+	<scope>(text.blade | text.html.blade | source.css.blade | source.js.blade) - custom.compiler.blade - meta.embedded.blade - source.php - text.plain - punctuation.section.embedded</scope>
 </snippet>

--- a/snippets/blade-layout-section.sublime-snippet
+++ b/snippets/blade-layout-section.sublime-snippet
@@ -5,5 +5,5 @@
 @show$0
 ]]></content>
 	<tabTrigger>lsec</tabTrigger>
-	<scope>text.blade</scope>
+	<scope>(text.blade | text.html.blade | source.css.blade | source.js.blade) - custom.compiler.blade - meta.embedded.blade - source.php - text.plain - punctuation.section.embedded</scope>
 </snippet>

--- a/snippets/blade-layout.sublime-snippet
+++ b/snippets/blade-layout.sublime-snippet
@@ -2,8 +2,6 @@
 	<content><![CDATA[
 @layout('${1:name}')$0
 ]]></content>
-	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
 	<tabTrigger>lay</tabTrigger>
-	<!-- Optional: Set a scope to limit where the snippet will trigger -->
-	<scope>text.blade</scope>
+	<scope>(text.blade | text.html.blade | source.css.blade | source.js.blade) - custom.compiler.blade - meta.embedded.blade - source.php - text.plain - punctuation.section.embedded</scope>
 </snippet>

--- a/snippets/blade-macro.sublime-snippet
+++ b/snippets/blade-macro.sublime-snippet
@@ -4,8 +4,6 @@
 	${0:command}
 @endmacro
 ]]></content>
-	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
 	<tabTrigger>macro</tabTrigger>
-	<!-- Optional: Set a scope to limit where the snippet will trigger -->
-	<scope>text.blade</scope>
+	<scope>(text.blade | text.html.blade | source.css.blade | source.js.blade) - custom.compiler.blade - meta.embedded.blade - source.php - text.plain - punctuation.section.embedded</scope>
 </snippet>

--- a/snippets/blade-method.sublime-snippet
+++ b/snippets/blade-method.sublime-snippet
@@ -1,9 +1,7 @@
 <snippet>
-    <content><![CDATA[
+	<content><![CDATA[
 @method('${1:PUT}')$0
 ]]></content>
-    <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
-    <tabTrigger>method</tabTrigger>
-    <!-- Optional: Set a scope to limit where the snippet will trigger -->
-    <scope>text.blade</scope>
+	<tabTrigger>method</tabTrigger>
+	<scope>(text.blade | text.html.blade | source.css.blade | source.js.blade) - custom.compiler.blade - meta.embedded.blade - source.php - text.plain - punctuation.section.embedded</scope>
 </snippet>

--- a/snippets/blade-parent.sublime-snippet
+++ b/snippets/blade-parent.sublime-snippet
@@ -2,8 +2,6 @@
 	<content><![CDATA[
 @parent
 ]]></content>
-	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
 	<tabTrigger>par</tabTrigger>
-	<!-- Optional: Set a scope to limit where the snippet will trigger -->
-	<scope>text.blade</scope>
+	<scope>(text.blade | text.html.blade | source.css.blade | source.js.blade) - custom.compiler.blade - meta.embedded.blade - source.php - text.plain - punctuation.section.embedded</scope>
 </snippet>

--- a/snippets/blade-php.sublime-snippet
+++ b/snippets/blade-php.sublime-snippet
@@ -4,8 +4,6 @@
 	${1:{{-- expr --\}\}}
 @endphp$0
 ]]></content>
-	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
 	<tabTrigger>php</tabTrigger>
-	<!-- Optional: Set a scope to limit where the snippet will trigger -->
-	<scope>text.blade</scope>
+	<scope>(text.blade | text.html.blade | source.css.blade | source.js.blade) - custom.compiler.blade - meta.embedded.blade - source.php - text.plain - punctuation.section.embedded</scope>
 </snippet>

--- a/snippets/blade-prepend.sublime-snippet
+++ b/snippets/blade-prepend.sublime-snippet
@@ -1,11 +1,9 @@
 <snippet>
-    <content><![CDATA[
+	<content><![CDATA[
 @prepend('${1:name}')
-    ${0:{{-- expr --\}\}}
+	${0:{{-- expr --\}\}}
 @endprepend
 ]]></content>
-    <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
-    <tabTrigger>prepend</tabTrigger>
-    <!-- Optional: Set a scope to limit where the snippet will trigger -->
-    <scope>text.blade</scope>
+	<tabTrigger>prepend</tabTrigger>
+	<scope>(text.blade | text.html.blade | source.css.blade | source.js.blade) - custom.compiler.blade - meta.embedded.blade - source.php - text.plain - punctuation.section.embedded</scope>
 </snippet>

--- a/snippets/blade-push.sublime-snippet
+++ b/snippets/blade-push.sublime-snippet
@@ -4,8 +4,6 @@
 	${0:{{-- expr --\}\}}
 @endpush
 ]]></content>
-	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
 	<tabTrigger>push</tabTrigger>
-	<!-- Optional: Set a scope to limit where the snippet will trigger -->
-	<scope>text.blade</scope>
+	<scope>(text.blade | text.html.blade | source.css.blade | source.js.blade) - custom.compiler.blade - meta.embedded.blade - source.php - text.plain - punctuation.section.embedded</scope>
 </snippet>

--- a/snippets/blade-route.sublime-snippet
+++ b/snippets/blade-route.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
-    <content><![CDATA[
+	<content><![CDATA[
 {{ route('${0:name}') }}
 ]]></content>
-    <tabTrigger>route</tabTrigger>
-    <scope>text.blade</scope>
+	<tabTrigger>route</tabTrigger>
+	<scope>(text.blade | text.html.blade | source.css.blade | source.js.blade) - custom.compiler.blade - meta.embedded.blade - source.php - text.plain - punctuation.section.embedded</scope>
 </snippet>

--- a/snippets/blade-section.sublime-snippet
+++ b/snippets/blade-section.sublime-snippet
@@ -4,8 +4,6 @@
 	${0:{{-- expr --\}\}}
 @endsection
 ]]></content>
-	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
 	<tabTrigger>sec</tabTrigger>
-	<!-- Optional: Set a scope to limit where the snippet will trigger -->
-	<scope>text.blade</scope>
+	<scope>(text.blade | text.html.blade | source.css.blade | source.js.blade) - custom.compiler.blade - meta.embedded.blade - source.php - text.plain - punctuation.section.embedded</scope>
 </snippet>

--- a/snippets/blade-section_simple.sublime-snippet
+++ b/snippets/blade-section_simple.sublime-snippet
@@ -1,8 +1,8 @@
 <snippet>
-    <content><![CDATA[
+	<content><![CDATA[
 @section('${1:section}', '${2:content}')
 ]]></content>
-    <tabTrigger>secsim</tabTrigger>
-    <scope>text.blade</scope>
-    <description>Defines a section with simple value</description>
+	<tabTrigger>secsim</tabTrigger>
+	<scope>(text.blade | text.html.blade | source.css.blade | source.js.blade) - custom.compiler.blade - meta.embedded.blade - source.php - text.plain - punctuation.section.embedded</scope>
+	<description>Defines a section with simple value</description>
 </snippet>

--- a/snippets/blade-section_yield.sublime-snippet
+++ b/snippets/blade-section_yield.sublime-snippet
@@ -4,8 +4,6 @@
 	${0:{{-- expr --\}\}}
 @yield_section
 ]]></content>
-	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
 	<tabTrigger>secy</tabTrigger>
-	<!-- Optional: Set a scope to limit where the snippet will trigger -->
-	<scope>text.blade</scope>
+	<scope>(text.blade | text.html.blade | source.css.blade | source.js.blade) - custom.compiler.blade - meta.embedded.blade - source.php - text.plain - punctuation.section.embedded</scope>
 </snippet>

--- a/snippets/blade-servers.sublime-snippet
+++ b/snippets/blade-servers.sublime-snippet
@@ -2,8 +2,6 @@
 	<content><![CDATA[
 @servers(['${1:web}' => '${2:user@192.168.1.1}'])$0
 ]]></content>
-	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
 	<tabTrigger>serv</tabTrigger>
-	<!-- Optional: Set a scope to limit where the snippet will trigger -->
-	<scope>text.blade</scope>
+	<scope>(text.blade | text.html.blade | source.css.blade | source.js.blade) - custom.compiler.blade - meta.embedded.blade - source.php - text.plain - punctuation.section.embedded</scope>
 </snippet>

--- a/snippets/blade-setup.sublime-snippet
+++ b/snippets/blade-setup.sublime-snippet
@@ -4,8 +4,6 @@
 	${0:{{-- expr --\}\}}
 @endsetup
 ]]></content>
-	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
 	<tabTrigger>setup</tabTrigger>
-	<!-- Optional: Set a scope to limit where the snippet will trigger -->
-	<scope>text.blade</scope>
+	<scope>(text.blade | text.html.blade | source.css.blade | source.js.blade) - custom.compiler.blade - meta.embedded.blade - source.php - text.plain - punctuation.section.embedded</scope>
 </snippet>

--- a/snippets/blade-slack.sublime-snippet
+++ b/snippets/blade-slack.sublime-snippet
@@ -2,8 +2,6 @@
 	<content><![CDATA[
 @slack('${1:hook}', '${2:channel}', '${3:message}')$0
 ]]></content>
-	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
 	<tabTrigger>sla</tabTrigger>
-	<!-- Optional: Set a scope to limit where the snippet will trigger -->
-	<scope>text.blade</scope>
+	<scope>(text.blade | text.html.blade | source.css.blade | source.js.blade) - custom.compiler.blade - meta.embedded.blade - source.php - text.plain - punctuation.section.embedded</scope>
 </snippet>

--- a/snippets/blade-slot.sublime-snippet
+++ b/snippets/blade-slot.sublime-snippet
@@ -1,10 +1,10 @@
 <snippet>
-    <content><![CDATA[
+	<content><![CDATA[
 @slot('${1:slot}')
-    $2
+	$2
 @endslot
 ]]></content>
-    <tabTrigger>slot</tabTrigger>
-    <scope>text.blade</scope>
-    <description>Defines a slot of a component</description>
+	<tabTrigger>slot</tabTrigger>
+	<scope>(text.blade | text.html.blade | source.css.blade | source.js.blade) - custom.compiler.blade - meta.embedded.blade - source.php - text.plain - punctuation.section.embedded</scope>
+	<description>Defines a slot of a component</description>
 </snippet>

--- a/snippets/blade-stack.sublime-snippet
+++ b/snippets/blade-stack.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
-    <content><![CDATA[
+	<content><![CDATA[
 @stack('${1:view}')$0
 ]]></content>
-    <tabTrigger>stack</tabTrigger>
-    <scope>text.blade</scope>
+	<tabTrigger>stack</tabTrigger>
+	<scope>(text.blade | text.html.blade | source.css.blade | source.js.blade) - custom.compiler.blade - meta.embedded.blade - source.php - text.plain - punctuation.section.embedded</scope>
 </snippet>

--- a/snippets/blade-story.sublime-snippet
+++ b/snippets/blade-story.sublime-snippet
@@ -4,8 +4,6 @@
 	${0:command}
 @endstory
 ]]></content>
-	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
 	<tabTrigger>story</tabTrigger>
-	<!-- Optional: Set a scope to limit where the snippet will trigger -->
-	<scope>text.blade</scope>
+	<scope>(text.blade | text.html.blade | source.css.blade | source.js.blade) - custom.compiler.blade - meta.embedded.blade - source.php - text.plain - punctuation.section.embedded</scope>
 </snippet>

--- a/snippets/blade-switch.sublime-snippet
+++ b/snippets/blade-switch.sublime-snippet
@@ -1,17 +1,15 @@
 <snippet>
-    <content><![CDATA[
+	<content><![CDATA[
 @switch(\$${1:i})
-    @case(${2:case1})
-        ${3:First case...}
-        @break
+	@case(${2:case1})
+	${3:First case...}
+	@break
 
-    ${4:@default
-            ${5:Default case...}}
+	${4:@default
+		${5:Default case...}}
 @endswitch
 $0
 ]]></content>
-    <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
-    <tabTrigger>switch</tabTrigger>
-    <!-- Optional: Set a scope to limit where the snippet will trigger -->
-    <scope>text.blade</scope>
+	<tabTrigger>switch</tabTrigger>
+	<scope>(text.blade | text.html.blade | source.css.blade | source.js.blade) - custom.compiler.blade - meta.embedded.blade - source.php - text.plain - punctuation.section.embedded</scope>
 </snippet>

--- a/snippets/blade-task.sublime-snippet
+++ b/snippets/blade-task.sublime-snippet
@@ -4,8 +4,6 @@
 	${0:command}
 @endtask
 ]]></content>
-	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
 	<tabTrigger>task</tabTrigger>
-	<!-- Optional: Set a scope to limit where the snippet will trigger -->
-	<scope>text.blade</scope>
+	<scope>(text.blade | text.html.blade | source.css.blade | source.js.blade) - custom.compiler.blade - meta.embedded.blade - source.php - text.plain - punctuation.section.embedded</scope>
 </snippet>

--- a/snippets/blade-trans.sublime-snippet
+++ b/snippets/blade-trans.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
-    <content><![CDATA[
+	<content><![CDATA[
 {{ trans('${0:language.line}') }}
 ]]></content>
-    <tabTrigger>trans</tabTrigger>
-    <scope>text.blade</scope>
+	<tabTrigger>trans</tabTrigger>
+	<scope>(text.blade | text.html.blade | source.css.blade | source.js.blade) - custom.compiler.blade - meta.embedded.blade - source.php - text.plain - punctuation.section.embedded</scope>
 </snippet>

--- a/snippets/blade-trans_variant.sublime-snippet
+++ b/snippets/blade-trans_variant.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
-    <content><![CDATA[
+	<content><![CDATA[
 {{ __('${0:language.line}') }}
 ]]></content>
-    <tabTrigger>__</tabTrigger>
-    <scope>text.blade</scope>
+	<tabTrigger>__</tabTrigger>
+	<scope>(text.blade | text.html.blade | source.css.blade | source.js.blade) - custom.compiler.blade - meta.embedded.blade - source.php - text.plain - punctuation.section.embedded</scope>
 </snippet>

--- a/snippets/blade-unless.sublime-snippet
+++ b/snippets/blade-unless.sublime-snippet
@@ -4,8 +4,6 @@
 	${2:{{-- expr --\}\}}
 @endunless$0
 ]]></content>
-	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
 	<tabTrigger>unless</tabTrigger>
-	<!-- Optional: Set a scope to limit where the snippet will trigger -->
-	<scope>text.blade</scope>
+	<scope>(text.blade | text.html.blade | source.css.blade | source.js.blade) - custom.compiler.blade - meta.embedded.blade - source.php - text.plain - punctuation.section.embedded</scope>
 </snippet>

--- a/snippets/blade-url.sublime-snippet
+++ b/snippets/blade-url.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
-    <content><![CDATA[
+	<content><![CDATA[
 {{ url('${0:path}') }}
 ]]></content>
-    <tabTrigger>url</tabTrigger>
-    <scope>text.blade</scope>
+	<tabTrigger>url</tabTrigger>
+	<scope>(text.blade | text.html.blade | source.css.blade | source.js.blade) - custom.compiler.blade - meta.embedded.blade - source.php - text.plain - punctuation.section.embedded</scope>
 </snippet>

--- a/snippets/blade-var.sublime-snippet
+++ b/snippets/blade-var.sublime-snippet
@@ -2,8 +2,6 @@
 	<content><![CDATA[
 {!! ${0:\$var} !!}
 ]]></content>
-	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
 	<tabTrigger>!!</tabTrigger>
-	<!-- Optional: Set a scope to limit where the snippet will trigger -->
-	<scope>text.blade</scope>
+	<scope>(text.blade | text.html.blade | source.css.blade | source.js.blade) - custom.compiler.blade - meta.embedded.blade - source.php - text.plain - punctuation.section.embedded</scope>
 </snippet>

--- a/snippets/blade-verbatim.sublime-snippet
+++ b/snippets/blade-verbatim.sublime-snippet
@@ -1,10 +1,10 @@
 <snippet>
-    <content><![CDATA[
+	<content><![CDATA[
 @verbatim
-    ${1:code}
+	${1:code}
 @endverbatim
 ]]></content>
-    <tabTrigger>verb</tabTrigger>
-    <scope>text.blade</scope>
-    <description>Display JavaScript variables in a large portion</description>
+	<tabTrigger>verb</tabTrigger>
+	<scope>(text.blade | text.html.blade | source.css.blade | source.js.blade) - custom.compiler.blade - meta.embedded.blade - source.php - text.plain - punctuation.section.embedded</scope>
+	<description>Display JavaScript variables in a large portion</description>
 </snippet>

--- a/snippets/blade-while.sublime-snippet
+++ b/snippets/blade-while.sublime-snippet
@@ -4,8 +4,6 @@
 	${2:{{-- expr --\}\}}
 @endwhile$0
 ]]></content>
-	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
 	<tabTrigger>while</tabTrigger>
-	<!-- Optional: Set a scope to limit where the snippet will trigger -->
-	<scope>text.blade</scope>
+	<scope>(text.blade | text.html.blade | source.css.blade | source.js.blade) - custom.compiler.blade - meta.embedded.blade - source.php - text.plain - punctuation.section.embedded</scope>
 </snippet>

--- a/snippets/blade-wpposts_wpempty.sublime-snippet
+++ b/snippets/blade-wpposts_wpempty.sublime-snippet
@@ -1,13 +1,11 @@
 <snippet>
-    <content><![CDATA[
+	<content><![CDATA[
 @wpposts
-    ${1:{{-- Loop --\}\}}
+	${1:{{-- Loop --\}\}}
 @wpempty
-    ${2:{{-- Empty --\}\}}
+	${2:{{-- Empty --\}\}}
 @wpend$0
 ]]></content>
-    <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
-    <tabTrigger>wpp</tabTrigger>
-    <!-- Optional: Set a scope to limit where the snippet will trigger -->
-    <scope>text.blade</scope>
+	<tabTrigger>wpp</tabTrigger>
+	<scope>(text.blade | text.html.blade | source.css.blade | source.js.blade) - custom.compiler.blade - meta.embedded.blade - source.php - text.plain - punctuation.section.embedded</scope>
 </snippet>

--- a/snippets/blade-wpquery_wpempty.sublime-snippet
+++ b/snippets/blade-wpquery_wpempty.sublime-snippet
@@ -1,13 +1,11 @@
 <snippet>
-    <content><![CDATA[
+	<content><![CDATA[
 @wpquery (${1:['post_type' => 'post']})
-    ${2:{{-- expr --\}\}}
+	${2:{{-- expr --\}\}}
 @wpempty
-    ${3:{{-- empty expr --\}\}}
+	${3:{{-- empty expr --\}\}}
 @wpend$0
 ]]></content>
-    <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
-    <tabTrigger>wpq</tabTrigger>
-    <!-- Optional: Set a scope to limit where the snippet will trigger -->
-    <scope>text.blade</scope>
+	<tabTrigger>wpq</tabTrigger>
+	<scope>(text.blade | text.html.blade | source.css.blade | source.js.blade) - custom.compiler.blade - meta.embedded.blade - source.php - text.plain - punctuation.section.embedded</scope>
 </snippet>

--- a/snippets/blade-yield.sublime-snippet
+++ b/snippets/blade-yield.sublime-snippet
@@ -2,8 +2,6 @@
 	<content><![CDATA[
 @yield('${1:name}'${2:, '${3:default}'})$0
 ]]></content>
-	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
-	<tabTrigger>yl</tabTrigger>
-	<!-- Optional: Set a scope to limit where the snippet will trigger -->
-	<scope>text.blade</scope>
+		<tabTrigger>yl</tabTrigger>
+		<scope>(text.blade | text.html.blade | source.css.blade | source.js.blade) - custom.compiler.blade - meta.embedded.blade - source.php - text.plain - punctuation.section.embedded</scope>
 </snippet>


### PR DESCRIPTION
This commit...

1. adjusts `scope` to  
   a) be forward compatible with a rewritten Laravel Blade syntax, which uses `text.html.blade` main scope.  
   see: https://github.com/Medalink/laravel-blade/pull/195   
   b) avoid snippets from being triggered within directives or embedded php source code.
2. removes template comments from snippet files.
3. modifies indentation from 4 space to tab.

Note: Overall content of snippets is maintained unchanged.